### PR TITLE
generate sitemap using `html_pages`

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -8,7 +8,7 @@
     <priority>0.8</priority>
   </url>
   {% endfor %}
-  {% for post in site.pages %}
+  {% for post in site.html_pages %}
   <url>
     <loc>{{ site_url }}{{ post.url | replace:'index.html','' }}</loc>
     <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>

--- a/spec/fixtures/feeds/atom.xml
+++ b/spec/fixtures/feeds/atom.xml
@@ -1,0 +1,6 @@
+---
+---
+
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+</feed>

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -45,5 +45,6 @@ describe(Jekyll::JekyllSitemap) do
 
   it "does not include assets or any static files that aren't .html" do
     expect(contents).not_to match /<loc>http:\/\/example\.org\/images\/hubot\.png<\/loc>/
+    expect(contents).not_to match /<loc>http:\/\/example\.org\/feeds\/atom\.xml<\/loc>/
   end
 end


### PR DESCRIPTION
It was a fairly simple to fix the issue where non-html pages (feeds) were included in the sitemap. Using `pages` will include all files irrespective of their extension, so I've changed this to `html_pages` in the sitemap template.

Fixes #9.
