### PR TITLE
Exclude a post or page from sitemap

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {% capture site_url %}{% if site.url %}{{ site.url }}{% else %}{{ site.github.url }}{% endif %}{% endcapture %}
-  {% for post in site.posts %}
+  {% for post in site.posts %}{% unless post.sitemap == false %}
   <url>
     <loc>{{ site_url }}{{ post.url }}</loc>
     <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
     <priority>0.8</priority>
   </url>
-  {% endfor %}
-  {% for post in site.html_pages %}
+  {% endunless %}{% endfor %}
+  {% for post in site.html_pages %}{% unless post.sitemap == false %}
   <url>
     <loc>{{ site_url }}{{ post.url | replace:'index.html','' }}</loc>
     <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>{% if post.url == "/" or post.url == "/index.html" %}1.0{% else %}0.7{% endif %}</priority>
   </url>
-  {% endfor %}
+  {% endunless %}{% endfor %}
   {% for file in site.html_files %}
   <url>
     <loc>{{ site_url }}{{ file.path }}</loc>

--- a/spec/fixtures/_posts/2014-05-11-exclude-this-post.md
+++ b/spec/fixtures/_posts/2014-05-11-exclude-this-post.md
@@ -1,0 +1,5 @@
+---
+sitemap: false
+---
+
+This post should not appear in the sitemap.

--- a/spec/fixtures/some-subfolder/exclude-this-page.html
+++ b/spec/fixtures/some-subfolder/exclude-this-page.html
@@ -1,0 +1,5 @@
+---
+sitemap: false
+---
+
+Exclude this page

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -47,4 +47,12 @@ describe(Jekyll::JekyllSitemap) do
     expect(contents).not_to match /<loc>http:\/\/example\.org\/images\/hubot\.png<\/loc>/
     expect(contents).not_to match /<loc>http:\/\/example\.org\/feeds\/atom\.xml<\/loc>/
   end
+
+  it "does not include posts that have set 'sitemap: false'" do
+    expect(contents).not_to match /\/exclude-this-post\.html<\/loc>/
+  end
+
+  it "does not include pages that have set 'sitemap: false'" do
+    expect(contents).not_to match /\/exclude-this-page\.html<\/loc>/
+  end
 end


### PR DESCRIPTION
Use `sitemap: false` to exclude a post or page from sitemap

This can be used to exclude `404.html` and such things.

Fixes #9.
