### PR TITLE
remove TEENY version requirement from ruby 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.1.0
+- 2.1
 - 2.0.0
 - 1.9.3
 script: "script/cibuild"


### PR DESCRIPTION
Builds against 2.1 are failing since the travis config references `2.1.0`

see https://github.com/travis-ci/travis-ci/issues/2220
