### PR TITLE
Usage in combination with other gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ gems:
   - jekyll-sitemap
 ```
 
+Make sure to place the `jekyll-sitemap` gem before any other content generating gem that you wish to exclude. As the sitemap will include all dirs and `.html` files.
+
 ## Developing locally
 
 Use `script/bootstrap` to bootstrap your local development environment.


### PR DESCRIPTION
Updated the readme with info about use in combination with other gems. This will hopefully help solve similar issues as the one I was having.

See https://github.com/jekyll/jekyll-sitemap/pull/11#issuecomment-42773286

``` shell
$ gem query -n jekyll --local

*** LOCAL GEMS ***

jekyll (2.0.3, 1.5.1)
jekyll-redirect-from (0.4.0, 0.3.1)
jekyll-sitemap (0.4.1, 0.2.0)
```

Faulty `_config.yml` that makes `sitemap.xml` contain redirect paths:

```
…
gems: ['jekyll-redirect-from', 'jekyll-sitemap']
```

Working `_config.yml`:

```
…
gems: ['jekyll-sitemap', 'jekyll-redirect-from']
```
