### PR TITLE
Allow `post.updated` to override `post.date`

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -4,7 +4,7 @@
   {% for post in site.posts %}{% unless post.sitemap == false %}
   <url>
     <loc>{{ site_url }}{{ post.url }}</loc>
-    <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+    <lastmod>{% if post.updated %}{{ post.updated | date_to_xmlschema }}{% else %}{{ post.date | date_to_xmlschema }}{% endif %}</lastmod>
     <priority>0.8</priority>
   </url>
   {% endunless %}{% endfor %}


### PR DESCRIPTION
Is anybody else keeping track of last update with a front matter variable?

Discuss.
