### PR TITLE
A few bug fixes and a configuration option for page and post priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ gems:
   - jekyll-sitemap
 ```
 
+## Customizing
+
+You can change sitemap settings for individual pages.
+
+To exclude a page or post from the sitemap, add `sitemap: false` to the page's or post's front matter.
+
+To override the priority of your page or post:
+
+```yml
+sitemap:
+  priority: 0.9
+```
+
 ## Developing locally
 
 Use `script/bootstrap` to bootstrap your local development environment.

--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -19,7 +19,7 @@
   {% for file in site.html_files %}
   <url>
     <loc>{{ site_url }}{{ file.path }}</loc>
-    <lastmod>{{ file.modified_time | date:"%Y-%m-%dT%H:%M:%sZ" }}</lastmod>
+    <lastmod>{{ file.modified_time | date:"%Y-%m-%dT%H:%M:%SZ" }}</lastmod>
     <priority>0.6</priority>
   </url>
   {% endfor %}

--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -5,7 +5,7 @@
   <url>
     <loc>{{ site_url }}{{ post.url }}</loc>
     <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
-    <priority>0.8</priority>
+    <priority>{% if post.sitemap.priority %}{{ post.sitemap.priority }}{% else %}0.8{% endif %}</priority>
   </url>
   {% endunless %}{% endfor %}
   {% for post in site.html_pages %}{% unless post.sitemap == false %}
@@ -13,7 +13,7 @@
     <loc>{{ site_url }}{{ post.url | replace:'index.html','' }}</loc>
     <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>{% if post.url == "/" or post.url == "/index.html" %}1.0{% else %}0.7{% endif %}</priority>
+    <priority>{% if post.sitemap.priority %}{{ post.sitemap.priority }}{% else %}{% if post.url == "/" or post.url == "/index.html" %}1.0{% else %}0.7{% endif %}{% endif %}</priority>
   </url>
   {% endunless %}{% endfor %}
   {% for file in site.html_files %}

--- a/spec/fixtures/_posts/2015-06-03-low-priority-post.md
+++ b/spec/fixtures/_posts/2015-06-03-low-priority-post.md
@@ -1,0 +1,6 @@
+---
+sitemap:
+  priority: 0.3
+---
+
+This post has a rather low priority.

--- a/spec/fixtures/some-subfolder/this-has-priority.html
+++ b/spec/fixtures/some-subfolder/this-has-priority.html
@@ -1,0 +1,6 @@
+---
+sitemap:
+  priority: 0.9
+---
+
+This page has high priority

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -15,7 +15,7 @@ describe(Jekyll::JekyllSitemap) do
   end
 
   it "creates a sitemap.xml file" do
-    expect(File.exist?(dest_dir("sitemap.xml"))).to be_true
+    expect(File.exist?(dest_dir("sitemap.xml"))).to be_truthy
   end
 
   it "sets the base URL for the site as priority 1.0" do

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -59,4 +59,12 @@ describe(Jekyll::JekyllSitemap) do
   it "correctly formats timestamps of static files" do
     expect(contents).to match /\/this-is-a-subfile\.html<\/loc>\s+<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z<\/lastmod>/
   end
+
+  it "allows overriding page priority" do
+    expect(contents).to match /\/this-has-priority\.html<\/loc>\s+<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(-|\+)\d{2}:\d{2}<\/lastmod>\s+<changefreq>weekly<\/changefreq>\s+<priority>0\.9<\/priority>/
+  end
+
+  it "allows overriding post priority" do
+    expect(contents).to match /\/low-priority-post\.html<\/loc>\s+<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(-|\+)\d{2}:\d{2}<\/lastmod>\s+<priority>0\.3<\/priority>/
+  end
 end

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -55,4 +55,8 @@ describe(Jekyll::JekyllSitemap) do
   it "does not include pages that have set 'sitemap: false'" do
     expect(contents).not_to match /\/exclude-this-page\.html<\/loc>/
   end
+
+  it "correctly formats timestamps of static files" do
+    expect(contents).to match /\/this-is-a-subfile\.html<\/loc>\s+<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z<\/lastmod>/
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ require File.expand_path('../lib/jekyll-sitemap', File.dirname(__FILE__))
 Jekyll.logger.log_level = :error
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.order = 'random'


### PR DESCRIPTION
Before I could add my feature, I had to fix a few bugs so it would pass all the rspec cases. I'd rather not do a pull request for everything in one lump, but I'm not exactly sure how to do it. So here are the changes I did:

1. Update the specs to work on rspec 3.0: be_true is now be_truthy
2. Correctly format timestamps of static files: Use %S for seconds of the minute instead of %s for seconds since the UNIX epoch
3. Allow overriding priority for pages and posts
4. Document the above option I implemented and the existing option to exclude a page or post from the sitemap