### PR TITLE
Remove default Priority

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -9,14 +9,12 @@
     {% else %}
     <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
     {% endif %}
-    <priority>0.8</priority>
   </url>
   {% endunless %}{% endfor %}
   {% for page in site.html_pages %}{% unless page.sitemap == false %}
   <url>
     <loc>{{ page.url | replace:'index.html','' | prepend: site_url }}</loc>
     <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
-    <priority>{% if page.url == "/" or page.url == "/index.html" %}1.0{% else %}0.7{% endif %}</priority>
   </url>
   {% endunless %}{% endfor %}
   {% for collection in site.collections %}{% unless collection.last.output == false %}
@@ -24,7 +22,6 @@
   <url>
     <loc>{{ doc.url | replace:'index.html','' | prepend: site_url }}</loc>
     <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
-    <priority>{% if doc.url == "/" or doc.url == "/index.html" %}1.0{% else %}0.7{% endif %}</priority>
   </url>
   {% endunless %}{% endfor %}
   {% endunless %}{% endfor %}
@@ -32,7 +29,6 @@
   <url>
     <loc>{{ file.path | prepend: site_url }}</loc>
     <lastmod>{{ file.modified_time | date_to_xmlschema }}</lastmod>
-    <priority>0.6</priority>
   </url>
   {% endfor %}
 </urlset>

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -29,10 +29,6 @@ describe(Jekyll::JekyllSitemap) do
     expect(File.exist?(dest_dir("sitemap.xml"))).to be_truthy
   end
 
-  it "sets the base URL for the site as priority 1.0" do
-    expect(contents).to match /<loc>http:\/\/example\.org\/<\/loc>\s+<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(-|\+)\d{2}:\d{2}<\/lastmod>\s+<priority>1\.0<\/priority>/
-  end
-
   it "puts all the pages in the sitemap.xml file" do
     expect(contents).to match /<loc>http:\/\/example\.org\/<\/loc>/
     expect(contents).to match /<loc>http:\/\/example\.org\/some-subfolder\/this-is-a-subpage\.html<\/loc>/


### PR DESCRIPTION
Removes the default priority for all items as per [Google's recommendations](https://github.com/jekyll/jekyll-sitemap/pull/21#issuecomment-50813988)

#21