### PR TITLE
Do not assume all pages have changed

### DIFF
--- a/jekyll-sitemap.gemspec
+++ b/jekyll-sitemap.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "jekyll", "~> 2.0"
+  spec.add_development_dependency "jekyll-last-modified-at", "0.3.4"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/lib/jekyll-sitemap.rb
+++ b/lib/jekyll-sitemap.rb
@@ -9,6 +9,7 @@ module Jekyll
 
   class JekyllSitemap < Jekyll::Generator
     safe true
+    priority :lowest
 
     # Main plugin action, called by Jekyll-core
     def generate(site)

--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -14,14 +14,18 @@
   {% for page in site.html_pages %}{% unless page.sitemap == false %}
   <url>
     <loc>{{ page.url | replace:'/index.html','/' | prepend: site_url }}</loc>
-    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+    {% if page.last_modified_at %}
+    <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
+    {% endif %}
   </url>
   {% endunless %}{% endfor %}
   {% for collection in site.collections %}{% unless collection.last.output == false %}
   {% for doc in collection.last.docs %}{% unless doc.sitemap == false %}
   <url>
     <loc>{{ doc.url | replace:'/index.html','/' | prepend: site_url }}</loc>
-    <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+    {% if doc.last_modified_at %}
+    <lastmod>{{ doc.last_modified_at | date_to_xmlschema }}</lastmod>
+    {% endif %}
   </url>
   {% endunless %}{% endfor %}
   {% endunless %}{% endfor %}

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,3 +1,4 @@
 #! /bin/bash
 
 bundle exec rspec
+bundle exec rspec spec/test_jekyll-last-modified-at.rb

--- a/spec/fixtures/_config.yml
+++ b/spec/fixtures/_config.yml
@@ -1,3 +1,5 @@
+timezone: UTC
+
 defaults:
   -
     scope:

--- a/spec/fixtures/_posts/2015-01-18-jekyll-last-modified-at.md
+++ b/spec/fixtures/_posts/2015-01-18-jekyll-last-modified-at.md
@@ -1,0 +1,4 @@
+---
+---
+
+Please don't modify this file. It's modified time is important.

--- a/spec/fixtures/jekyll-last-modified-at/page.html
+++ b/spec/fixtures/jekyll-last-modified-at/page.html
@@ -1,0 +1,4 @@
+---
+---
+
+This is a page with a modified time.

--- a/spec/test_jekyll-last-modified-at.rb
+++ b/spec/test_jekyll-last-modified-at.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'jekyll-last-modified-at'
+
+describe(Jekyll::JekyllSitemap) do
+  let(:overrides) do
+    {
+      "source"      => source_dir,
+      "destination" => dest_dir,
+      "url"         => "http://example.org",
+      "collections" => {
+        "my_collection" => { "output" => true },
+        "other_things"  => { "output" => false }
+      }
+    }
+  end
+  let(:config) do
+    Jekyll.configuration(overrides)
+  end
+  let(:site)     { Jekyll::Site.new(config) }
+  let(:contents) { File.read(dest_dir("sitemap.xml")) }
+  before(:each) do
+    site.process
+  end
+
+  context "with jekyll-last-modified-at" do
+    it "correctly adds the modified time to the posts" do
+      expect(contents).to match  /<loc>http:\/\/example.org\/2015\/01\/18\/jekyll-last-modified-at.html<\/loc>\s+<lastmod>2015-01-19T07:03:38\+00:00<\/lastmod>/
+    end
+
+    it "correctly adds the modified time to the pages" do
+      expect(contents).to match  /<loc>http:\/\/example.org\/jekyll-last-modified-at\/page.html<\/loc>\s+<lastmod>2015-01-19T07:03:38\+00:00<\/lastmod>/
+    end
+  end
+end


### PR DESCRIPTION
`<lastmod>` [is an optional tag](http://www.sitemaps.org/protocol.html#lastmoddef).

Including it as we currently do has the advantage of letting search engines know if nothing on the site has changed for quite a while (as in, the site has not been regenerated), but the disadvantage of telling search engines that every page on the site has changed each time the site is regenerated, even if no pages have been updated.

I'm not really sure which is worse&hellip;