### PR TITLE
Add checks that drafts are not added to the sitemap.xml

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {% capture site_url %}{% if site.url %}{{ site.url }}{% else %}{{ site.github.url }}{% endif %}{% endcapture %}
-  {% for post in site.posts %}{% unless post.sitemap == false %}
+  {% for post in site.posts %}{% unless post.sitemap == false %}{% unless post.draft %}
   <url>
     <loc>{{ site_url }}{{ post.url }}</loc>
     <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
     <priority>0.8</priority>
   </url>
-  {% endunless %}{% endfor %}
-  {% for post in site.html_pages %}{% unless post.sitemap == false %}
+  {% endunless %}{% endunless %}{% endfor %}
+  {% for post in site.html_pages %}{% unless post.sitemap == false %}{% unless post.draft %}
   <url>
     <loc>{{ site_url }}{{ post.url | replace:'index.html','' }}</loc>
     <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>{% if post.url == "/" or post.url == "/index.html" %}1.0{% else %}0.7{% endif %}</priority>
   </url>
-  {% endunless %}{% endfor %}
+  {% endunless %}{% endunless %}{% endfor %}
   {% for file in site.html_files %}
   <url>
     <loc>{{ site_url }}{{ file.path }}</loc>

--- a/spec/fixtures/_posts/2014-08-01-exclude-drafts.md
+++ b/spec/fixtures/_posts/2014-08-01-exclude-drafts.md
@@ -1,0 +1,5 @@
+---
+draft: true
+---
+
+This post should not appear in the sitemap.

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -63,4 +63,8 @@ describe(Jekyll::JekyllSitemap) do
   it "correctly formats timestamps of static files" do
     expect(contents).to match /\/this-is-a-subfile\.html<\/loc>\s+<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z<\/lastmod>/
   end
+
+  it "does not include posts that have set 'draft: true'" do
+    expect(contents).not_to match /\/exclude-drafts\.html<\/loc>/
+  end
 end


### PR DESCRIPTION
If you have any drafts in your _posts folder they will be added to the sitemap and potentially indexed by the bots
