### PR TITLE
Use `post.last_modified_at` for post lastmod

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -4,7 +4,11 @@
   {% for post in site.posts %}{% unless post.sitemap == false %}
   <url>
     <loc>{{ site_url }}{{ post.url }}</loc>
+    {% if post.last_modified_at %}
+    <lastmod>{{ post.last_modified_at | date_to_xmlschema }}</lastmod>
+    {% else %}
     <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+    {% endif %}
     <priority>0.8</priority>
   </url>
   {% endunless %}{% endfor %}


### PR DESCRIPTION
If **[jekyll-modified-at](https://github.com/gjtorikian/jekyll-last-modified-at)** is installed, use that for a post `<lastmod>` instead of `post.date`

Fixes #18
