### PR TITLE
Strip extra whitespace from output

### DIFF
--- a/lib/jekyll-sitemap.rb
+++ b/lib/jekyll-sitemap.rb
@@ -42,7 +42,7 @@ module Jekyll
       site_map.content = File.read(source_path)
       site_map.data["layout"] = nil
       site_map.render(Hash.new, @site.site_payload)
-      site_map.output
+      site_map.output.gsub(/[\s\n]*\n+/, "\n")
     end
 
     # Checks if a sitemap already exists in the site source


### PR DESCRIPTION
Implementation of my comment in [#37](https://github.com/jekyll/jekyll-sitemap/pull/37#issuecomment-54694831)

This will remove all blank newlines from the sitemap before it is written. This will not make the output file meaningfully smaller (especially if the output will be gzipped), but it does enhance the readability of the output.

My previous sitemap:

``` xml

<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">


  <url>
    <loc>http://example.com/post1.html</loc>

    <lastmod>2014-08-22T18:57:00-05:00</lastmod>

    <priority>0.8</priority>
  </url>

  <url>
    <loc>http://example.com/post2.html</loc>

    <lastmod>2014-04-17T00:00:00-05:00</lastmod>

    <priority>0.8</priority>
  </url>
...
```

My sitemap with blank lines stripped:

``` xml

<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url>
    <loc>http://example.com/post1.html</loc>
    <lastmod>2014-08-22T18:57:00-05:00</lastmod>
    <priority>0.8</priority>
  </url>
  <url>
    <loc>http://example.com/post2.html</loc>
    <lastmod>2014-04-17T00:00:00-05:00</lastmod>
    <priority>0.8</priority>
  </url>
...
```
