### PR TITLE
Use baseurl in sitemap.xml

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {% capture site_url %}{% if site.url %}{{ site.url }}{% else %}{{ site.github.url }}{% endif %}{% endcapture %}
+  {% capture site_url %}{% if site.url %}{{ site.url | append: site.baseurl }}{% else %}{{ site.github.url }}{% endif %}{% endcapture %}
   {% for post in site.posts %}{% unless post.sitemap == false %}
   <url>
     <loc>{{ site_url }}{{ post.url }}</loc>


### PR DESCRIPTION
Does this fix jekyll/jekyll-sitemap#47?

This will almost certainly break sites. Since `site.url` isn't _really_ part of Jekyll proper, or documented anywhere, we might want to add something to the documentation about how and when to use `site.url` and/or `site.baseurl`
