### PR TITLE
Don't strip 'index.html' when there is more to filename

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -13,14 +13,14 @@
   {% endunless %}{% endfor %}
   {% for page in site.html_pages %}{% unless page.sitemap == false %}
   <url>
-    <loc>{{ page.url | replace:'index.html','' | prepend: site_url }}</loc>
+    <loc>{{ page.url | replace:'/index.html','/' | prepend: site_url }}</loc>
     <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
   </url>
   {% endunless %}{% endfor %}
   {% for collection in site.collections %}{% unless collection.last.output == false %}
   {% for doc in collection.last.docs %}{% unless doc.sitemap == false %}
   <url>
-    <loc>{{ doc.url | replace:'index.html','' | prepend: site_url }}</loc>
+    <loc>{{ doc.url | replace:'/index.html','/' | prepend: site_url }}</loc>
     <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
   </url>
   {% endunless %}{% endfor %}

--- a/spec/fixtures/some-subfolder/test_index.html
+++ b/spec/fixtures/some-subfolder/test_index.html
@@ -1,0 +1,4 @@
+---
+---
+
+The permalink of this page does not end with a '/', but with a filename

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -34,6 +34,10 @@ describe(Jekyll::JekyllSitemap) do
     expect(contents).to match /<loc>http:\/\/example\.org\/some-subfolder\/this-is-a-subpage\.html<\/loc>/
   end
 
+  it "only strips 'index.html' from end of permalink" do
+    expect(contents).to match /<loc>http:\/\/example\.org\/some-subfolder\/test_index\.html<\/loc>/
+  end
+
   it "puts all the posts in the sitemap.xml file" do
     expect(contents).to match /<loc>http:\/\/example\.org\/2014\/03\/04\/march-the-fourth\.html<\/loc>/
     expect(contents).to match /<loc>http:\/\/example\.org\/2014\/03\/02\/march-the-second\.html<\/loc>/


### PR DESCRIPTION
Fixes #67 

I wish that Liquid provided a `replace_last` filter analogous to [`replace_first`](https://github.com/Shopify/liquid/blob/master/lib/liquid/standardfilters.rb#L160-L163).

This could break things if there is a directory named `/index.html/` or a file who's name begins with `/index.html`