### PR TITLE
Remove duplicated range from regex

### DIFF
--- a/lib/jekyll-sitemap.rb
+++ b/lib/jekyll-sitemap.rb
@@ -53,7 +53,7 @@ module Jekyll
       site_map.content = File.read(source_path)
       site_map.data["layout"] = nil
       site_map.render(Hash.new, @site.site_payload)
-      site_map.output.gsub(/[\s\n]*\n+/, "\n")
+      site_map.output.gsub(/\s*\n+/, "\n")
     end
 
     # Checks if a sitemap already exists in the site source

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -29,6 +29,11 @@ describe(Jekyll::JekyllSitemap) do
     expect(File.exist?(dest_dir("sitemap.xml"))).to be_truthy
   end
 
+  it "doesn't have multiple new lines or trailing whitespace" do
+    expect(contents).to_not match /\s+\n/
+    expect(contents).to_not match /\n{2,}/
+  end
+
   it "puts all the pages in the sitemap.xml file" do
     expect(contents).to match /<loc>http:\/\/example\.org\/<\/loc>/
     expect(contents).to match /<loc>http:\/\/example\.org\/some-subfolder\/this-is-a-subpage\.html<\/loc>/


### PR DESCRIPTION
I noticed jekyll-sitemap generates some warnings on Travis build: https://travis-ci.org/yous/yous.github.io/builds/52976809

- `/\s/` is equivalent to `/[ \t\r\n\f]/`. See http://ruby-doc.org/core-2.2.0/doc/regexp_rdoc.html#label-Character+Classes.