### PR TITLE
Enable excluding collections from sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ sitemap flag to `false` in the front matter for the page/post.
 sitemap: false
 ```
 
+Similarly, all pages in a collection can be excluded by setting the sitemap
+flag to `false` in the collection definition in `_config.yaml`.
+
 ## Developing locally
 
 Use `script/bootstrap` to bootstrap your local development environment.

--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -19,7 +19,7 @@
     {% endif %}
   </url>
   {% endunless %}{% endfor %}
-  {% for collection in site.collections %}{% unless collection.last.output == false %}
+  {% for collection in site.collections %}{% unless collection.sitemap == false or collection.last.output == false %}
   {% for doc in collection.last.docs %}{% unless doc.sitemap == false %}
   <url>
     <loc>{{ doc.url | replace:'/index.html','/' | prepend: site_url }}</loc>

--- a/spec/fixtures/_unwanted/exclude.html
+++ b/spec/fixtures/_unwanted/exclude.html
@@ -1,0 +1,4 @@
+---
+---
+
+Exclude this page

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -8,7 +8,8 @@ describe(Jekyll::JekyllSitemap) do
       "url"         => "http://example.org",
       "collections" => {
         "my_collection" => { "output" => true },
-        "other_things"  => { "output" => false }
+        "other_things"  => { "output" => false },
+        "unwanted"      => { "sitemap" => false }
       }
     }
   end
@@ -56,6 +57,10 @@ describe(Jekyll::JekyllSitemap) do
 
     it "doesn't put all the `output:false` into sitemap.xml" do
       expect(contents).to_not match /<loc>http:\/\/example\.org\/other_things\/test2\.html<\/loc>/
+    end
+
+    it "doesn't put all the `sitemap:false` into sitemap.xml" do
+      expect(contents).to_not match /<loc>http:\/\/example\.org\/unwanted\/exclude\.html<\/loc>/
     end
 
     it "remove 'index.html' for directory custom permalinks" do


### PR DESCRIPTION
I have collections of geojson files which shouldn't be in the sitemap. This change should exclude a collection if `sitemap: false` is defined in the collection settings in `_config.yaml`. Saves having to set it in each individual file.