### PR TITLE
URI encode sitemap URLs

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -3,7 +3,7 @@
   {% capture site_url %}{% if site.url %}{{ site.url | append: site.baseurl }}{% else %}{{ site.github.url }}{% endif %}{% endcapture %}
   {% for post in site.posts %}{% unless post.sitemap == false %}
   <url>
-    <loc>{{ post.url | prepend: site_url }}</loc>
+    <loc>{{ post.url | prepend: site_url | uri_escape }}</loc>
     {% if post.last_modified_at %}
     <lastmod>{{ post.last_modified_at | date_to_xmlschema }}</lastmod>
     {% else %}
@@ -13,7 +13,7 @@
   {% endunless %}{% endfor %}
   {% for page in site.html_pages %}{% unless page.sitemap == false %}
   <url>
-    <loc>{{ page.url | replace:'/index.html','/' | prepend: site_url }}</loc>
+    <loc>{{ page.url | replace:'/index.html','/' | prepend: site_url | uri_escape }}</loc>
     {% if page.last_modified_at %}
     <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
     {% endif %}
@@ -22,7 +22,7 @@
   {% for collection in site.collections %}{% unless collection.last.output == false or collection.output == false %}
   {% for doc in collection.last.docs %}{% unless doc.sitemap == false %}
   <url>
-    <loc>{{ doc.url | replace:'/index.html','/' | prepend: site_url }}</loc>
+    <loc>{{ doc.url | replace:'/index.html','/' | prepend: site_url | uri_escape }}</loc>
     {% if doc.last_modified_at %}
     <lastmod>{{ doc.last_modified_at | date_to_xmlschema }}</lastmod>
     {% endif %}
@@ -30,7 +30,7 @@
   {% endunless %}{% endfor %}
   {% for doc in collection.docs %}{% unless doc.sitemap == false %}
     <url>
-      <loc>{{ doc.url | replace:'/index.html','/' | prepend: site_url }}</loc>
+      <loc>{{ doc.url | replace:'/index.html','/' | prepend: site_url | uri_escape }}</loc>
       {% if doc.last_modified_at %}
       <lastmod>{{ doc.last_modified_at | date_to_xmlschema }}</lastmod>
       {% endif %}
@@ -39,7 +39,7 @@
   {% endunless %}{% endfor %}
   {% for file in site.html_files %}
   <url>
-    <loc>{{ file.path | prepend: site_url }}</loc>
+    <loc>{{ file.path | prepend: site_url | uri_escape }}</loc>
     <lastmod>{{ file.modified_time | date_to_xmlschema }}</lastmod>
   </url>
   {% endfor %}

--- a/spec/fixtures/_my_collection/this-has-non-standard-chars.md
+++ b/spec/fixtures/_my_collection/this-has-non-standard-chars.md
@@ -1,0 +1,5 @@
+---
+permalink: this url has an ümlaut
+---
+
+# URL contains characters that need to be URI encoded

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require 'spec_helper'
 
 describe(Jekyll::JekyllSitemap) do
@@ -65,6 +67,10 @@ describe(Jekyll::JekyllSitemap) do
     it "doesn't remove filename for non-directory custom permalinks" do
       expect(contents).to match /<loc>http:\/\/example\.org\/permalink\/unique_name\.html<\/loc>/
     end
+
+    it "performs URI encoding of site paths" do
+      expect(contents).to match /<loc>http:\/\/example\.org\/this%20url%20has%20an%20%C3%BCmlaut<\/loc>/
+    end
   end
 
   it "generates the correct date for each of the posts" do
@@ -116,6 +122,22 @@ describe(Jekyll::JekyllSitemap) do
       expect(contents).to match /<loc>http:\/\/example\.org\/bass\/2014\/03\/04\/march-the-fourth\.html<\/loc>/
       expect(contents).to match /<loc>http:\/\/example\.org\/bass\/2014\/03\/02\/march-the-second\.html<\/loc>/
       expect(contents).to match /<loc>http:\/\/example\.org\/bass\/2013\/12\/12\/dec-the-second\.html<\/loc>/
+    end
+  end
+
+  context "with site url that needs URI encoding" do
+    let(:config) do
+      Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(overrides, {"url" => "http://has ümlaut.org"}))
+    end
+
+    it "performs URI encoding of site url" do
+      expect(contents).to match /<loc>http:\/\/has%20%C3%BCmlaut\.org\/<\/loc>/
+      expect(contents).to match /<loc>http:\/\/has%20%C3%BCmlaut\.org\/some-subfolder\/this-is-a-subpage\.html<\/loc>/
+      expect(contents).to match /<loc>http:\/\/has%20%C3%BCmlaut\.org\/2014\/03\/04\/march-the-fourth\.html<\/loc>/
+    end
+
+    it "does not double-escape site url" do
+      expect(contents).to_not match /%25/
     end
   end
 end


### PR DESCRIPTION
* All sitemap URLs are required to be URI-encoded
* Adding built-in Jekyll template `uri_escape` handles this
* Test shows successful handling of non-alphanumeric and non-ASCII characters