### PR TITLE
Fix shebangs from /bin/bash to /bin/sh

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,3 +1,3 @@
-#! /bin/bash
+#!/bin/sh
 
 bundle install

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/sh
 set -e
 
 bundle exec rspec


### PR DESCRIPTION
These simple scripts do not use any bash features, so do not
require needless extra dependency