### PR TITLE
Fix GitHub Pages tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
 - 2.2
 matrix:
   include:
+    - # GitHub Pages
+      rvm: 2.1.1
+      env: JEKYLL_VERSION=2.4.0
     - rvm: 1.9.3
       env: JEKYLL_VERSION=2.5
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source "https://rubygems.org"
 gemspec
 
-if ENV["GH_PAGES"]
-  gem "github-pages"
-elsif ENV["JEKYLL_VERSION"]
+if ENV["JEKYLL_VERSION"]
   gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}"
 end


### PR DESCRIPTION
I split the GitHub pages stuff into its own gemfile to avoid environment variable trickery.

It seems that for some reason bundler chokes when loading this project's gem with the **pages-gem**. It obviously wasn't this way before, I am unsure of what changed.

It seems I can get around that by loading our test version of **jekyll-sitemap** by path rather than through `gemspec`, but I have no idea what the implications of that are. We would need to add all the dev deps by hand; seems like a nasty terrible hack.

I will admit that I'm in a bit over my head here. Any suggestions would be greatly appreciated.