### PR TITLE
Do not include 'posts' collection twice

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -19,7 +19,7 @@
     {% endif %}
   </url>
   {% endunless %}{% endfor %}
-  {% for collection in site.collections %}{% unless collection.last.output == false or collection.output == false %}
+  {% for collection in site.collections %}{% unless collection.last.output == false or collection.output == false or collection.label == 'posts' %}
   {% for doc in collection.last.docs %}{% unless doc.sitemap == false %}
   <url>
     <loc>{{ doc.url | replace:'/index.html','/' | prepend: site_url | uri_escape }}</loc>

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -100,6 +100,10 @@ describe(Jekyll::JekyllSitemap) do
     expect(contents).to match /\/this-is-a-subfile\.html<\/loc>\s+<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(-|\+)\d{2}:\d{2}<\/lastmod>/
   end
 
+  it "includes the correct number of items" do
+    expect(contents.scan(/(?=<url>)/).count).to eql 13
+  end
+
   context "with a baseurl" do
     let(:config) do
       Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(overrides, {"baseurl" => "/bass"}))


### PR DESCRIPTION
Here is a first attempt at fixing #91 in a way that is backward compatible with Jekyll 2.