### PR TITLE
Allow HTML files to end with .xhtml or .htm

### DIFF
--- a/lib/jekyll-sitemap.rb
+++ b/lib/jekyll-sitemap.rb
@@ -23,9 +23,15 @@ module Jekyll
       end
     end
 
+    HTML_EXTENSIONS = %W(
+      .html
+      .xhtml
+      .htm
+    )
+
     # Array of all non-jekyll site files with an HTML extension
     def html_files
-      @site.static_files.select { |file| File.extname(file.relative_path) == ".html" }
+      @site.static_files.select { |file| HTML_EXTENSIONS.include? file.extname }
     end
 
     # Path to sitemap.xml template file

--- a/spec/fixtures/some-subfolder/htm.htm
+++ b/spec/fixtures/some-subfolder/htm.htm
@@ -1,0 +1,1 @@
+This file has an .htm extension, and should be included in the sitemap

--- a/spec/fixtures/some-subfolder/xhtml.xhtml
+++ b/spec/fixtures/some-subfolder/xhtml.xhtml
@@ -1,0 +1,1 @@
+This file has an .xhtml extension, and should be included in the sitemap

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -88,6 +88,11 @@ describe(Jekyll::JekyllSitemap) do
     expect(contents).not_to match /<loc>http:\/\/example\.org\/feeds\/atom\.xml<\/loc>/
   end
 
+  it "does include assets or any static files with .xhtml and .htm extensions" do
+    expect(contents).to match /\/some-subfolder\/xhtml\.xhtml/
+    expect(contents).to match /\/some-subfolder\/htm\.htm/
+  end
+
   it "does not include posts that have set 'sitemap: false'" do
     expect(contents).not_to match /\/exclude-this-post\.html<\/loc>/
   end
@@ -101,7 +106,7 @@ describe(Jekyll::JekyllSitemap) do
   end
 
   it "includes the correct number of items" do
-    expect(contents.scan(/(?=<url>)/).count).to eql 13
+    expect(contents.scan(/(?=<url>)/).count).to eql 15
   end
 
   context "with a baseurl" do


### PR DESCRIPTION
This mirrors [Jekyll's current behavior](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/page.rb#L19-L26) as of Jekyll/Jekyll#4160