### PR TITLE
Minify sitemap template

### DIFF
--- a/lib/jekyll-sitemap.rb
+++ b/lib/jekyll-sitemap.rb
@@ -50,7 +50,7 @@ module Jekyll
 
     def sitemap_content
       site_map = PageWithoutAFile.new(@site, File.dirname(__FILE__), "", "sitemap.xml")
-      site_map.content = File.read(source_path)
+      site_map.content = File.read(source_path).strip.gsub(/\s+/,' ').gsub(/[>}]\s+[<{]/){|s| s.gsub(/\s+/,'')}
       site_map.data["layout"] = nil
       site_map.render(Hash.new, @site.site_payload)
       site_map.output.gsub(/\s*\n+/, "\n")

--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {% capture site_url %}{% if site.url %}{{ site.url | append: site.baseurl }}{% else %}{{ site.github.url }}{% endif %}{% endcapture %}
+
   {% for post in site.posts %}{% unless post.sitemap == false %}
   <url>
     <loc>{{ post.url | prepend: site_url | uri_escape }}</loc>
@@ -11,6 +12,7 @@
     {% endif %}
   </url>
   {% endunless %}{% endfor %}
+
   {% for page in site.html_pages %}{% unless page.sitemap == false %}
   <url>
     <loc>{{ page.url | replace:'/index.html','/' | prepend: site_url | uri_escape }}</loc>
@@ -19,6 +21,7 @@
     {% endif %}
   </url>
   {% endunless %}{% endfor %}
+
   {% for collection in site.collections %}{% unless collection.last.output == false or collection.output == false or collection.label == 'posts' %}
   {% for doc in collection.last.docs %}{% unless doc.sitemap == false %}
   <url>
@@ -37,10 +40,12 @@
     </url>
   {% endunless %}{% endfor %}
   {% endunless %}{% endfor %}
+
   {% for file in site.html_files %}
   <url>
     <loc>{{ file.path | prepend: site_url | uri_escape }}</loc>
     <lastmod>{{ file.modified_time | date_to_xmlschema }}</lastmod>
   </url>
   {% endfor %}
+
 </urlset>

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -97,7 +97,7 @@ describe(Jekyll::JekyllSitemap) do
   end
 
   it "correctly formats timestamps of static files" do
-    expect(contents).to match /\/this-is-a-subfile\.html<\/loc>\s+<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(-|\+)\d{2}:\d{2}<\/lastmod>/
+    expect(contents).to match /\/this-is-a-subfile\.html<\/loc>\s*<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(-|\+)\d{2}:\d{2}<\/lastmod>/
   end
 
   it "includes the correct number of items" do

--- a/spec/test_jekyll-last-modified-at.rb
+++ b/spec/test_jekyll-last-modified-at.rb
@@ -24,11 +24,11 @@ describe(Jekyll::JekyllSitemap) do
 
   context "with jekyll-last-modified-at" do
     it "correctly adds the modified time to the posts" do
-      expect(contents).to match  /<loc>http:\/\/example.org\/2015\/01\/18\/jekyll-last-modified-at.html<\/loc>\s+<lastmod>2015-01-19T07:03:38\+00:00<\/lastmod>/
+      expect(contents).to match  /<loc>http:\/\/example.org\/2015\/01\/18\/jekyll-last-modified-at.html<\/loc>\s*<lastmod>2015-01-19T07:03:38\+00:00<\/lastmod>/
     end
 
     it "correctly adds the modified time to the pages" do
-      expect(contents).to match  /<loc>http:\/\/example.org\/jekyll-last-modified-at\/page.html<\/loc>\s+<lastmod>2015-01-19T07:03:38\+00:00<\/lastmod>/
+      expect(contents).to match  /<loc>http:\/\/example.org\/jekyll-last-modified-at\/page.html<\/loc>\s*<lastmod>2015-01-19T07:03:38\+00:00<\/lastmod>/
     end
   end
 end


### PR DESCRIPTION
We should not sacrifice readability in our template just to minimize the amount of whitespace introduced into the generated sitemap.

This PR will remove whitespace from the Liquid template before rendering the sitemap, so that whitespace may be used liberally in the template without increasing the size of the output XML.