### PR TITLE
Use {} instead of Hash.new

### DIFF
--- a/lib/jekyll-sitemap.rb
+++ b/lib/jekyll-sitemap.rb
@@ -58,7 +58,7 @@ module Jekyll
       site_map = PageWithoutAFile.new(@site, File.dirname(__FILE__), "", "sitemap.xml")
       site_map.content = File.read(source_path)
       site_map.data["layout"] = nil
-      site_map.render(Hash.new, @site.site_payload)
+      site_map.render({}, @site.site_payload)
       site_map.output.gsub(/\s*\n+/, "\n")
     end
 


### PR DESCRIPTION
> Smell - Semantics - Invalid Hash Initialization - Use `{}` instead of `Hash` to initialize a hash.