### PR TITLE
Allow a custom sitemap.xml destination file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ those other gems if you *want* the sitemap to include the generated
 content, or *before* those other gems if you *don't want* the sitemap to
 include the generated content from the gems. (Programming is *hard*.)
 
+## Settings
+
+If you'd like the sitemap to go somewhere other than `/sitemap.xml` (for
+example, if you're using a sitemap index), add the location to your
+`_config.yml`:
+
+```yml
+sitemap:
+  location: somewhere/else/sitemap.xml
+```
+
 ## Exclusions
 
 If you would like to exclude specific pages/posts from the sitemap set the

--- a/lib/jekyll/jekyll-sitemap.rb
+++ b/lib/jekyll/jekyll-sitemap.rb
@@ -12,7 +12,7 @@ module Jekyll
       unless sitemap_exists?
         write
         @site.keep_files ||= []
-        @site.keep_files << "sitemap.xml"
+        @site.keep_files << destination_file_name
       end
     end
 
@@ -33,13 +33,17 @@ module Jekyll
       File.expand_path "../sitemap.xml", File.dirname(__FILE__)
     end
 
-    # Destination for sitemap.xml file within the site source directory
+    # Destination for sitemap file within the site source directory
     def destination_path
       if @site.respond_to?(:in_dest_dir)
-        @site.in_dest_dir("sitemap.xml")
+        @site.in_dest_dir(destination_file_name)
       else
-        Jekyll.sanitized_path(@site.dest, "sitemap.xml")
+        Jekyll.sanitized_path(@site.dest, destination_file_name)
       end
+    end
+
+    def destination_file_name
+      @site.config.fetch("sitemap", {})["location"] || "sitemap.xml"
     end
 
     # copy sitemap template from source to destination
@@ -49,7 +53,7 @@ module Jekyll
     end
 
     def sitemap_content
-      site_map = PageWithoutAFile.new(@site, File.dirname(__FILE__), "", "sitemap.xml")
+      site_map = PageWithoutAFile.new(@site, File.dirname(__FILE__), "", destination_file_name)
       site_map.content = File.read(source_path)
       site_map.data["layout"] = nil
       site_map.data["static_files"] = static_files.map(&:to_liquid)
@@ -60,9 +64,9 @@ module Jekyll
     # Checks if a sitemap already exists in the site source
     def sitemap_exists?
       if @site.respond_to?(:in_source_dir)
-        File.exist? @site.in_source_dir("sitemap.xml")
+        File.exist? @site.in_source_dir(destination_file_name)
       else
-        File.exist? Jekyll.sanitized_path(@site.source, "sitemap.xml")
+        File.exist? Jekyll.sanitized_path(@site.source, destination_file_name)
       end
     end
   end

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -31,6 +31,15 @@ describe(Jekyll::JekyllSitemap) do
     expect(File.exist?(dest_dir("sitemap.xml"))).to be_truthy
   end
 
+  it "can generate to somewhere other than /sitemap.xml" do
+    site = Jekyll::Site.new(
+      config.merge("sitemap" => { "location" => "other.xml" })
+    )
+    site.process
+
+    expect(File.exist?(dest_dir("other.xml"))).to be_truthy
+  end
+
   it "doesn't have multiple new lines or trailing whitespace" do
     expect(contents).to_not match /\s+\n/
     expect(contents).to_not match /\n{2,}/


### PR DESCRIPTION
Some users may want to hand-write [a sitemap index file](http://www.sitemaps.org/protocol.html#index). Since the index file must be named `sitemap.xml`, the sitemap can't also be named `sitemap.xml`.