### PR TITLE
Do not override site.time

### DIFF
--- a/lib/jekyll/jekyll-sitemap.rb
+++ b/lib/jekyll/jekyll-sitemap.rb
@@ -8,7 +8,7 @@ module Jekyll
     # Main plugin action, called by Jekyll-core
     def generate(site)
       @site = site
-      @site.config["time"] = Time.new
+      @site.config["time"] ||= Time.new
       unless sitemap_exists?
         write
         @site.keep_files ||= []


### PR DESCRIPTION
When we override `site.time`, apparently weird things can happen to drafts when Jekyll is set not to display future posts.

A plugin should not be setting `site.time` anyway, that's the job of Jekyll core. I would like to remove this line entirely in a future update when we can drop support for older versions of Jekyll, but for now maybe we can settle for only setting it once and only when it hasn't been set by anything else.

See jekyll/jekyll-feed#135