### PR TITLE
Don't set @site.config["time"] on sitemap generation

### DIFF
--- a/lib/jekyll/jekyll-sitemap.rb
+++ b/lib/jekyll/jekyll-sitemap.rb
@@ -8,7 +8,6 @@ module Jekyll
     # Main plugin action, called by Jekyll-core
     def generate(site)
       @site = site
-      @site.config["time"] = Time.new
       unless sitemap_exists?
         write
         @site.keep_files ||= []


### PR DESCRIPTION
Setting @site.config["time"] causes problems when Jekyll is operating in --draft mode. See: https://github.com/jekyll/jekyll-sitemap/issues/130 and https://github.com/jekyll/jekyll-feed/issues/135