### PR TITLE
Drop Addressable dependency

### DIFF
--- a/jekyll-sitemap.gemspec
+++ b/jekyll-sitemap.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "addressable", "~>2.4.0"
-
   spec.add_dependency "jekyll", "~> 3.3"
 
   spec.add_development_dependency "jekyll-last-modified-at", "0.3.4"


### PR DESCRIPTION
Now that Jekyll core is building absolute URLs for us, we're not using Addressable any more.