### PR TITLE
DRY in sitemap.xml

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -3,25 +3,28 @@
   <?xml-stylesheet type="text/xsl" href="{{ "/sitemap.xsl" | absolute_url }}"?>
 {% endif %}
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {% for collection in site.collections %}{% unless collection.output == false %}
-  {% for doc in collection.docs %}{% unless doc.sitemap == false %}
+  {% assign collections = site.collections | where_exp:'collection','collection.output != false' %}
+  {% for collection in collections %}
+  {% assign docs = collection.docs | where_exp:'doc','doc.sitemap != false' %}
+  {% for doc in docs %}
     <url>
       <loc>{{ doc.url | replace:'/index.html','/' | absolute_url }}</loc>
       {% if doc.last_modified_at or doc.date %}
       <lastmod>{{ doc.last_modified_at | default: doc.date | date_to_xmlschema }}</lastmod>
       {% endif %}
     </url>
-  {% endunless %}{% endfor %}
-  {% endunless %}{% endfor %}
+  {% endfor %}
+  {% endfor %}
 
-  {% for page in site.html_pages %}{% unless page.sitemap == false %}
+  {% assign pages = site.html_pages | where_exp:'doc','doc.sitemap != false' %}
+  {% for page in pages %}
   <url>
     <loc>{{ page.url | replace:'/index.html','/' | absolute_url }}</loc>
     {% if page.last_modified_at %}
     <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
     {% endif %}
   </url>
-  {% endunless %}{% endfor %}
+  {% endfor %}
 
   {% for file in page.static_files %}
   <url>

--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -17,15 +17,7 @@
     {% endif %}
   </url>
   {% endunless %}{% endfor %}
-  {% for collection in site.collections %}{% unless collection.last.output == false or collection.output == false or collection.label == 'posts' %}
-  {% for doc in collection.last.docs %}{% unless doc.sitemap == false %}
-  <url>
-    <loc>{{ doc.url | replace:'/index.html','/' | absolute_url }}</loc>
-    {% if doc.last_modified_at %}
-    <lastmod>{{ doc.last_modified_at | date_to_xmlschema }}</lastmod>
-    {% endif %}
-  </url>
-  {% endunless %}{% endfor %}
+  {% for collection in site.collections %}{% unless collection.output == false or collection.label == 'posts' %}
   {% for doc in collection.docs %}{% unless doc.sitemap == false %}
     <url>
       <loc>{{ doc.url | replace:'/index.html','/' | absolute_url }}</loc>

--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -3,14 +3,6 @@
   <?xml-stylesheet type="text/xsl" href="{{ "/sitemap.xsl" | absolute_url }}"?>
 {% endif %}
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {% for page in site.html_pages %}{% unless page.sitemap == false %}
-  <url>
-    <loc>{{ page.url | replace:'/index.html','/' | absolute_url }}</loc>
-    {% if page.last_modified_at %}
-    <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
-    {% endif %}
-  </url>
-  {% endunless %}{% endfor %}
   {% for collection in site.collections %}{% unless collection.output == false %}
   {% for doc in collection.docs %}{% unless doc.sitemap == false %}
     <url>
@@ -21,6 +13,16 @@
     </url>
   {% endunless %}{% endfor %}
   {% endunless %}{% endfor %}
+
+  {% for page in site.html_pages %}{% unless page.sitemap == false %}
+  <url>
+    <loc>{{ page.url | replace:'/index.html','/' | absolute_url }}</loc>
+    {% if page.last_modified_at %}
+    <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
+    {% endif %}
+  </url>
+  {% endunless %}{% endfor %}
+
   {% for file in page.static_files %}
   <url>
     <loc>{{ file.path | absolute_url }}</loc>

--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -5,31 +5,31 @@
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {% assign collections = site.collections | where_exp:'collection','collection.output != false' %}
   {% for collection in collections %}
-  {% assign docs = collection.docs | where_exp:'doc','doc.sitemap != false' %}
-  {% for doc in docs %}
-    <url>
-      <loc>{{ doc.url | replace:'/index.html','/' | absolute_url }}</loc>
-      {% if doc.last_modified_at or doc.date %}
-      <lastmod>{{ doc.last_modified_at | default: doc.date | date_to_xmlschema }}</lastmod>
-      {% endif %}
-    </url>
-  {% endfor %}
+    {% assign docs = collection.docs | where_exp:'doc','doc.sitemap != false' %}
+    {% for doc in docs %}
+      <url>
+        <loc>{{ doc.url | replace:'/index.html','/' | absolute_url }}</loc>
+        {% if doc.last_modified_at or doc.date %}
+          <lastmod>{{ doc.last_modified_at | default: doc.date | date_to_xmlschema }}</lastmod>
+        {% endif %}
+      </url>
+    {% endfor %}
   {% endfor %}
 
   {% assign pages = site.html_pages | where_exp:'doc','doc.sitemap != false' %}
   {% for page in pages %}
-  <url>
-    <loc>{{ page.url | replace:'/index.html','/' | absolute_url }}</loc>
-    {% if page.last_modified_at %}
-    <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
-    {% endif %}
-  </url>
+    <url>
+      <loc>{{ page.url | replace:'/index.html','/' | absolute_url }}</loc>
+      {% if page.last_modified_at %}
+        <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
+      {% endif %}
+    </url>
   {% endfor %}
 
   {% for file in page.static_files %}
-  <url>
-    <loc>{{ file.path | absolute_url }}</loc>
-    <lastmod>{{ file.modified_time | date_to_xmlschema }}</lastmod>
-  </url>
+    <url>
+      <loc>{{ file.path | absolute_url }}</loc>
+      <lastmod>{{ file.modified_time | date_to_xmlschema }}</lastmod>
+    </url>
   {% endfor %}
 </urlset>

--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -3,12 +3,6 @@
   <?xml-stylesheet type="text/xsl" href="{{ "/sitemap.xsl" | absolute_url }}"?>
 {% endif %}
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {% for post in site.posts %}{% unless post.sitemap == false %}
-  <url>
-    <loc>{{ post.url | absolute_url }}</loc>
-    <lastmod>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</lastmod>
-  </url>
-  {% endunless %}{% endfor %}
   {% for page in site.html_pages %}{% unless page.sitemap == false %}
   <url>
     <loc>{{ page.url | replace:'/index.html','/' | absolute_url }}</loc>
@@ -17,12 +11,12 @@
     {% endif %}
   </url>
   {% endunless %}{% endfor %}
-  {% for collection in site.collections %}{% unless collection.output == false or collection.label == 'posts' %}
+  {% for collection in site.collections %}{% unless collection.output == false %}
   {% for doc in collection.docs %}{% unless doc.sitemap == false %}
     <url>
       <loc>{{ doc.url | replace:'/index.html','/' | absolute_url }}</loc>
-      {% if doc.last_modified_at %}
-      <lastmod>{{ doc.last_modified_at | date_to_xmlschema }}</lastmod>
+      {% if doc.last_modified_at or doc.date %}
+      <lastmod>{{ doc.last_modified_at | default: doc.date | date_to_xmlschema }}</lastmod>
       {% endif %}
     </url>
   {% endunless %}{% endfor %}


### PR DESCRIPTION
This monster of a PR attempts to reduce code reuse in the sitemap template.
- Drop support for Jekyll 2.x style collections (since we now require Jekyll 3.3+)
- Allow Posts to be output with other collections (since Posts are a collection in Jekyll 3+)
- Use new `where_exp` filter instead of `unless`

Ideally, I would love to only have the `<url>` template _once_ (instead of current three times). If `page.static_files`, `site.html_pages`, and `collection.docs` were arrays, I could use the Liquid `concat` filter to string them all together and iterate over everything in one for loop. I am not sure this is currently possible.
