### PR TITLE
Refactor and add sitemap to `site.pages`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 1.9
+  TargetRubyVersion: 2.0
   Include:
     - lib/*.rb
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ those other gems if you *want* the sitemap to include the generated
 content, or *before* those other gems if you *don't want* the sitemap to
 include the generated content from the gems. (Programming is *hard*.)
 
+Because the sitemap is added to `site.pages`, you may have to modify any
+templates that iterate through all pages (for example, to build a menu of
+all of the site's content).
+
 ## Exclusions
 
 If you would like to exclude specific pages/posts from the sitemap set the


### PR DESCRIPTION
This PR takes advantage of some of the newer features in Jekyll to reduce some of the code necessary. Now that we require Jekyll 3.3, we do not need to keep all the old workarounds.