### PR TITLE
Add robots.txt when none exists

### DIFF
--- a/lib/jekyll/jekyll-sitemap.rb
+++ b/lib/jekyll/jekyll-sitemap.rb
@@ -9,6 +9,7 @@ module Jekyll
     def generate(site)
       @site = site
       @site.pages << sitemap unless file_exists?("sitemap.xml")
+      @site.pages << robots unless file_exists?("robots.txt")
     end
 
     private
@@ -32,13 +33,13 @@ module Jekyll
     end
 
     # Path to sitemap.xml template file
-    def source_path
-      File.expand_path "../sitemap.xml", File.dirname(__FILE__)
+    def source_path(file = "sitemap.xml")
+      File.expand_path "../#{file}", File.dirname(__FILE__)
     end
 
     # Destination for sitemap.xml file within the site source directory
-    def destination_path
-      @site.in_dest_dir("sitemap.xml")
+    def destination_path(file = "sitemap.xml")
+      @site.in_dest_dir(file)
     end
 
     def sitemap
@@ -48,6 +49,13 @@ module Jekyll
       site_map.data["static_files"] = static_files.map(&:to_liquid)
       site_map.data["xsl"] = file_exists?("sitemap.xsl")
       site_map
+    end
+
+    def robots
+      robots = PageWithoutAFile.new(@site, File.dirname(__FILE__), "", "robots.txt")
+      robots.content = File.read(source_path("robots.txt"))
+      robots.data["layout"] = nil
+      robots
     end
 
     # Checks if a file already exists in the site source

--- a/lib/robots.txt
+++ b/lib/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: {{ "sitemap.xml" | relative_url }}

--- a/lib/robots.txt
+++ b/lib/robots.txt
@@ -1,1 +1,1 @@
-Sitemap: {{ "sitemap.xml" | relative_url }}
+Sitemap: {{ "sitemap.xml" | absolute_url }}

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -139,7 +139,7 @@ describe(Jekyll::JekyllSitemap) do
 
     it "adds baseurl to robots.txt" do
       content = File.read(dest_dir("robots.txt"))
-      expect(content).to match("Sitemap: /bass/sitemap.xml")
+      expect(content).to match("Sitemap: http://example.org/bass/sitemap.xml")
     end
   end
 
@@ -173,7 +173,7 @@ describe(Jekyll::JekyllSitemap) do
       end
 
       it "renders liquid" do
-        expect(contents).to match("Sitemap: /sitemap.xml")
+        expect(contents).to match("Sitemap: http://xn--mlaut-jva.example.org/sitemap.xml")
       end
     end
   end

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -136,6 +136,11 @@ describe(Jekyll::JekyllSitemap) do
       expect(contents).to match /<loc>http:\/\/example\.org\/bass\/2014\/03\/02\/march-the-second\.html<\/loc>/
       expect(contents).to match /<loc>http:\/\/example\.org\/bass\/2013\/12\/12\/dec-the-second\.html<\/loc>/
     end
+
+    it "adds baseurl to robots.txt" do
+      content = File.read(dest_dir("robots.txt"))
+      expect(content).to match("Sitemap: /bass/sitemap.xml")
+    end
   end
 
   context "with urls that needs URI encoding" do
@@ -154,6 +159,22 @@ describe(Jekyll::JekyllSitemap) do
 
     it "does not double-escape urls" do
       expect(contents).to_not match /%25/
+    end
+
+    context "readme" do
+      let(:contents) { File.read(dest_dir("robots.txt")) }
+
+      it "has no layout" do
+        expect(contents).not_to match(/\ATHIS IS MY LAYOUT/)
+      end
+
+      it "creates a sitemap.xml file" do
+        expect(File.exist?(dest_dir("robots.txt"))).to be_truthy
+      end
+
+      it "renders liquid" do
+        expect(contents).to match("Sitemap: /sitemap.xml")
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/jekyll/jekyll-sitemap/issues/114.
