### PR TITLE
Allow Travis to build tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
 branches:
   only:
   - master
+  - /^v\d+\.\d+\.\d+/
 git:
   depth: 1000
 install:


### PR DESCRIPTION
Ok, so Travis didn't auto-deploy the new :gem: as I had hoped.

After doing some digging, it seems Travis wasn't auto-deploying tags because it wasn't building tags at all.  Travis sees tags as branches, so by telling Travis to only build the master branch, Travis will never build tags.

```yaml
branches:
  only:
  - master
```

The last time [Travis built a tag was v0.9.0](https://travis-ci.org/jekyll/jekyll-sitemap/branches) which [did not include the `branches: only: - master` directive](https://github.com/jekyll/jekyll-sitemap/blob/v0.9.0/.travis.yml). Once [this was added in v0.10.0](https://github.com/jekyll/jekyll-sitemap/blob/v0.10.0/.travis.yml#L18-L20), Travis stopped building tags.

Travis sees tags as branches, so by allowing _branches_ that look like a tag, Travis should build our tags as well, which will allow it to deploy them :+1:

The other option would be to remove the `branches` condition altogether, which I would be equally ok with. 👌 