### PR TITLE
Proposal to exclude paths (Partial issue #119)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 cache: bundler
 before_install:
   - gem update --system
+  - gem update bundler
 rvm:
 - 2.0
 - 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: ruby
 cache: bundler
+before_install:
+  - gem update --system
 rvm:
 - 2.0
 - 2.1

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ sitemap flag to `false` in the front matter for the page/post.
 sitemap: false
 ```
 
+Alternatively, you can add full relative path or file in your \_config.yaml under `exclude_from_sitemap:`.
+
+```yml
+exclude_from_sitemap:
+  - /amp
+  - /foo.pdf
+  - /blog/2017/01/bar.pdf
+```
+
 ## Developing locally
 
 Use `script/bootstrap` to bootstrap your local development environment.

--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -7,29 +7,62 @@
   {% for collection in collections %}
     {% assign docs = collection.docs | where_exp:'doc','doc.sitemap != false' %}
     {% for doc in docs %}
-      <url>
-        <loc>{{ doc.url | replace:'/index.html','/' | absolute_url }}</loc>
-        {% if doc.last_modified_at or doc.date %}
-          <lastmod>{{ doc.last_modified_at | default: doc.date | date_to_xmlschema }}</lastmod>
+      {% assign include_url = true %}
+      {% for exclude_from in site.exclude_from_sitemap %}
+        {% assign exclude_from_size = exclude_from | size %}
+        {% assign truncated_url = doc.url | truncate: exclude_from_size, "" %}
+        {% if truncated_url == exclude_from %}
+          {% assign include_url = false %}
+          {% break %}
         {% endif %}
-      </url>
+      {% endfor %}
+      {% if include_url == true %}
+        <url>
+          <loc>{{ doc.url | replace:'/index.html','/' | absolute_url }}</loc>
+          {% if doc.last_modified_at or doc.date %}
+            <lastmod>{{ doc.last_modified_at | default: doc.date | date_to_xmlschema }}</lastmod>
+          {% endif %}
+        </url>
+      {% endif %}
     {% endfor %}
   {% endfor %}
 
   {% assign pages = site.html_pages | where_exp:'doc','doc.sitemap != false' %}
   {% for page in pages %}
-    <url>
-      <loc>{{ page.url | replace:'/index.html','/' | absolute_url }}</loc>
-      {% if page.last_modified_at %}
-        <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
+    {% assign include_url = true %}
+    {% for exclude_from in site.exclude_from_sitemap %}
+      {% assign exclude_from_size = exclude_from | size %}
+      {% assign truncated_url = page.url | truncate: exclude_from_size, "" %}
+      {% if truncated_url == exclude_from %}
+        {% assign include_url = false %}
+        {% break %}
       {% endif %}
-    </url>
+    {% endfor %}
+    {% if include_url == true %}
+      <url>
+        <loc>{{ page.url | replace:'/index.html','/' | absolute_url }}</loc>
+        {% if page.last_modified_at %}
+          <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
+        {% endif %}
+      </url>
+    {% endif %}
   {% endfor %}
 
   {% for file in page.static_files %}
-    <url>
-      <loc>{{ file.path | absolute_url }}</loc>
-      <lastmod>{{ file.modified_time | date_to_xmlschema }}</lastmod>
-    </url>
+    {% assign include_url = true %}
+    {% for exclude_from in site.exclude_from_sitemap %}
+      {% assign exclude_from_size = exclude_from | size %}
+      {% assign truncated_path = file.path | truncate: exclude_from_size, "" %}
+      {% if truncated_path == exclude_from %}
+        {% assign include_url = false %}
+        {% break %}
+      {% endif %}
+    {% endfor %}
+    {% if include_url == true %}
+      <url>
+        <loc>{{ file.path | absolute_url }}</loc>
+        <lastmod>{{ file.modified_time | date_to_xmlschema }}</lastmod>
+      </url>
+    {% endif %}
   {% endfor %}
 </urlset>


### PR DESCRIPTION
Hi. I had an issue where I was trying to omit paths from the sitemap generator (Just like #119), but there wasn't a solution yet. So I wrote one.

I would like to propose this partial solution. This does not work with wildcards or anything similar because the template is written in Liquid. I was unable to find any wildcard support.

Because of this, I propose allowing full path exclusions.

i.e., I have an AMP directory on my website so I would add this to my `_config.yaml`:

```yml
exclude_from_sitemap:
  - /amp
```

If I had a specific file, I would have:

```yml
exclude_from_sitemap:
  - /blog/files/foo.pdf
```

I am truncating the letters to guarantee that a phrase does not appear elsewhere in the Path because I'm using the Path to compare against.

I understand this is not optimal because there is no wildcard support, but this should get the job done on paths and files that don't have frontmatter.

What are your thoughts on this approach? 