### PR TITLE
Remove excluded static files from the sitemap

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -26,7 +26,7 @@
     </url>
   {% endfor %}
 
-  {% assign static_files = page.static_files | where_exp:'page','page.name != "404.html"' %}
+  {% assign static_files = page.static_files | where_exp:'page','page.sitemap != false' | where_exp:'page','page.name != "404.html"' %}
   {% for file in static_files %}
     <url>
       <loc>{{ file.path | absolute_url | xml_escape }}</loc>

--- a/spec/fixtures/_config.yml
+++ b/spec/fixtures/_config.yml
@@ -7,3 +7,8 @@ defaults:
       type: page
     values:
       layout: some_default
+  -
+    scope:
+      path: "static_files/excluded.pdf"
+    values:
+      sitemap: false

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -101,6 +101,10 @@ describe(Jekyll::JekyllSitemap) do
     expect(contents).not_to match %r!/static_files/404.html!
   end
 
+  it "does not include any static files that have set 'sitemap: false'" do
+    expect(contents).not_to match %r!/static_files/excluded\.pdf!
+  end
+
   it "does not include posts that have set 'sitemap: false'" do
     expect(contents).not_to match /\/exclude-this-post\.html<\/loc>/
   end


### PR DESCRIPTION
The `sitemap.xml` doesn't obey the `sitemap` front matter variable when looping over the static files (in the same way it does for collections and pages). This means excluded static files still get included in the generated sitemap.

This PR just checks that `sitemap != false` for static files, and adds in the necessary tests.