### PR TITLE
Condition the static file tests on Jekyll 3.4.2 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     env: JEKYLL_VERSION=3.4.3
 env:
   matrix:
+  - JEKYLL_VERSION=3.3.0
   - JEKYLL_VERSION=3.4
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ matrix:
   include:
   # GitHub Pages
   - rvm: 2.3.3
-    env: JEKYLL_VERSION=3.3.1
+    env: JEKYLL_VERSION=3.4.3
 env:
   matrix:
-  - JEKYLL_VERSION=3.3
+  - JEKYLL_VERSION=3.4
 branches:
   only:
   - master

--- a/jekyll-sitemap.gemspec
+++ b/jekyll-sitemap.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jekyll", "~> 3.4", ">= 3.4.2"
+  spec.add_dependency "jekyll", "~> 3.3"
 
   spec.add_development_dependency "jekyll-last-modified-at", "0.3.4"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/jekyll-sitemap.gemspec
+++ b/jekyll-sitemap.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jekyll", "~> 3.3"
+  spec.add_dependency "jekyll", "~> 3.4", ">= 3.4.2"
 
   spec.add_development_dependency "jekyll-last-modified-at", "0.3.4"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -101,8 +101,10 @@ describe(Jekyll::JekyllSitemap) do
     expect(contents).not_to match %r!/static_files/404.html!
   end
 
-  it "does not include any static files that have set 'sitemap: false'" do
-    expect(contents).not_to match %r!/static_files/excluded\.pdf!
+  if Gem::Version.new(Jekyll::VERSION) >= Gem::Version.new('3.4.2')
+    it "does not include any static files that have set 'sitemap: false'" do
+      expect(contents).not_to match %r!/static_files/excluded\.pdf!
+    end
   end
 
   it "does not include posts that have set 'sitemap: false'" do
@@ -122,7 +124,12 @@ describe(Jekyll::JekyllSitemap) do
   end
 
   it "includes the correct number of items" do
-    expect(contents.scan(/(?=<url>)/).count).to eql 19
+    # static_files/excluded.pdf is excluded on Jekyll 3.4.2 and above
+    if Gem::Version.new(Jekyll::VERSION) >= Gem::Version.new('3.4.2')
+      expect(contents.scan(/(?=<url>)/).count).to eql 19
+    else
+      expect(contents.scan(/(?=<url>)/).count).to eql 20
+    end
   end
 
   context "with a baseurl" do


### PR DESCRIPTION
This PR bumps the Jekyll gem dependency to [v3.4.2](https://github.com/jekyll/jekyll/releases/tag/v3.4.2) (the release containing front matter defaults for static files).

It also bumps the version used by the GitHub Pages test environment to [v3.4.3](https://github.com/jekyll/jekyll/releases/tag/v3.4.3) (the latest supported).