### PR TITLE
filter/replace static index.html paths to permalink

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -29,7 +29,7 @@
   {% assign static_files = page.static_files | where_exp:'page','page.sitemap != false' | where_exp:'page','page.name != "404.html"' %}
   {% for file in static_files %}
     <url>
-      <loc>{{ file.path | absolute_url | xml_escape }}</loc>
+      <loc>{{ file.path | replace:'/index.html','/' | absolute_url | xml_escape }}</loc>
       <lastmod>{{ file.modified_time | date_to_xmlschema }}</lastmod>
     </url>
   {% endfor %}

--- a/spec/fixtures/some-subfolder/index.html
+++ b/spec/fixtures/some-subfolder/index.html
@@ -1,0 +1,1 @@
+static subfolder index.html file that should be indexed as permalink

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -130,9 +130,9 @@ describe(Jekyll::JekyllSitemap) do
   it "includes the correct number of items" do
     # static_files/excluded.pdf is excluded on Jekyll 3.4.2 and above
     if Gem::Version.new(Jekyll::VERSION) >= Gem::Version.new('3.4.2')
-      expect(contents.scan(/(?=<url>)/).count).to eql 19
-    else
       expect(contents.scan(/(?=<url>)/).count).to eql 20
+    else
+      expect(contents.scan(/(?=<url>)/).count).to eql 21
     end
   end
 

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -88,6 +88,10 @@ describe(Jekyll::JekyllSitemap) do
     expect(contents).not_to match /<loc>http:\/\/example\.org\/feeds\/atom\.xml<\/loc>/
   end
 
+  it "converts static index.html files to permalink version" do
+    expect(contents).to match /<loc>http:\/\/example\.org\/some-subfolder\/<\/loc>/
+  end
+
   it "does include assets or any static files with .xhtml and .htm extensions" do
     expect(contents).to match /\/some-subfolder\/xhtml\.xhtml/
     expect(contents).to match /\/some-subfolder\/htm\.htm/
@@ -122,7 +126,7 @@ describe(Jekyll::JekyllSitemap) do
   end
 
   it "includes the correct number of items" do
-    expect(contents.scan(/(?=<url>)/).count).to eql 19
+    expect(contents.scan(/(?=<url>)/).count).to eql 20
   end
 
   context "with a baseurl" do


### PR DESCRIPTION
the default path for a subfolder index file is the permalink version:

`/directory/index.html` renders sitemap path as `/directory/`

felt the same should happen for static html files that are included. 

