### PR TITLE
Fix Travis Deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ matrix:
   include:
   # GitHub Pages
   - rvm: 2.4.0
-    env: JEKYLL_VERSION=3.4.3
+    env:
+    - JEKYLL_VERSION=3.4.3
+    - GITHUB_PAGES=1 # Only set on one build in matrix
 env:
   matrix:
   - JEKYLL_VERSION=3.3.0
@@ -43,3 +45,4 @@ deploy:
   on:
     tags: true
     repo: jekyll/jekyll-sitemap
+    condition: "$GITHUB_PAGES == 1"


### PR DESCRIPTION
This should make Travis only try to deploy a Gem once, and avoid the race condition encountered during the v1.1.0 release

This is a bit of a hack. To make sure that only one build tries to deploy, I am setting a special flag during the GHP build, and then only trying to deploy if that flag is set. This will prevent deploy during any other Travis build.

Fixes #165