### PR TITLE
Test that HTML files are excluded

### DIFF
--- a/lib/jekyll/jekyll-sitemap.rb
+++ b/lib/jekyll/jekyll-sitemap.rb
@@ -16,7 +16,7 @@ module Jekyll
 
     private
 
-    INCLUDED_EXTENSIONS = %W(
+    INCLUDED_EXTENSIONS = %w(
       .htm
       .html
       .xhtml

--- a/spec/fixtures/_config.yml
+++ b/spec/fixtures/_config.yml
@@ -12,3 +12,8 @@ defaults:
       path: "static_files/excluded.pdf"
     values:
       sitemap: false
+  -
+    scope:
+      path: "static_files/html_file.html"
+    values:
+      sitemap: false

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -109,6 +109,10 @@ describe(Jekyll::JekyllSitemap) do
     it "does not include any static files that have set 'sitemap: false'" do
       expect(contents).not_to match %r!/static_files/excluded\.pdf!
     end
+
+    it "does not include any static files that have set 'sitemap: false'" do
+      expect(contents).not_to match %r!/static_files/html_file\.html!
+    end
   end
 
   it "does not include posts that have set 'sitemap: false'" do


### PR DESCRIPTION
Looking into https://github.com/jekyll/jekyll-sitemap/issues/200, I realized that we test a binary file, but not a static text file, which may behave differently, per https://github.com/jekyll/jekyll-sitemap/issues/180.