### PR TITLE
Feature/correctly encode ellipsis

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -8,7 +8,7 @@
     {% assign docs = collection.docs | where_exp:'doc','doc.sitemap != false' %}
     {% for doc in docs %}
       <url>
-        <loc>{{ doc.url | replace:'/index.html','/' | absolute_url | xml_escape }}</loc>
+        <loc>{{ doc.url | replace:'/index.html','/' | replace:'…',':ellipsis:' | absolute_url | replace:':ellipsis:','%E2%80%A6' | xml_escape }}</loc>
         {% if doc.last_modified_at or doc.date %}
           <lastmod>{{ doc.last_modified_at | default: doc.date | date_to_xmlschema }}</lastmod>
         {% endif %}
@@ -19,7 +19,7 @@
   {% assign pages = site.html_pages | where_exp:'doc','doc.sitemap != false' | where_exp:'doc','doc.url != "/404.html"' %}
   {% for page in pages %}
     <url>
-      <loc>{{ page.url | replace:'/index.html','/' | absolute_url | xml_escape }}</loc>
+      <loc>{{ page.url | replace:'/index.html','/' | replace:'…',':ellipsis:' | absolute_url | replace:':ellipsis:','%E2%80%A6' | xml_escape }}</loc>
       {% if page.last_modified_at %}
         <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
       {% endif %}
@@ -29,7 +29,7 @@
   {% assign static_files = page.static_files | where_exp:'page','page.sitemap != false' | where_exp:'page','page.name != "404.html"' %}
   {% for file in static_files %}
     <url>
-      <loc>{{ file.path | replace:'/index.html','/' | absolute_url | xml_escape }}</loc>
+      <loc>{{ file.path | replace:'/index.html','/' | replace:'…',':ellipsis:' | absolute_url | replace:':ellipsis:','%E2%80%A6' | xml_escape }}</loc>
       <lastmod>{{ file.modified_time | date_to_xmlschema }}</lastmod>
     </url>
   {% endfor %}

--- a/spec/fixtures/_my_collection/this-has-an-ellipsis.md
+++ b/spec/fixtures/_my_collection/this-has-an-ellipsis.md
@@ -1,0 +1,5 @@
+---
+permalink: this url has an ellipsis…
+---
+
+# URL contains characters that need to be URI encoded

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -71,6 +71,10 @@ describe(Jekyll::JekyllSitemap) do
     it "performs URI encoding of site paths" do
       expect(contents).to match /<loc>http:\/\/example\.org\/this%20url%20has%20an%20%C3%BCmlaut<\/loc>/
     end
+
+    it "correctly encodes an ellipsis" do
+      expect(contents).to match /<loc>http:\/\/example\.org\/this%20url%20has%20an%20ellipsis%E2%80%A6<\/loc>/
+    end
   end
 
   it "generates the correct date for each of the posts" do
@@ -134,9 +138,9 @@ describe(Jekyll::JekyllSitemap) do
   it "includes the correct number of items" do
     # static_files/excluded.pdf is excluded on Jekyll 3.4.2 and above
     if Gem::Version.new(Jekyll::VERSION) >= Gem::Version.new("3.4.2")
-      expect(contents.scan(%r!(?=<url>)!).count).to eql 20
-    else
       expect(contents.scan(%r!(?=<url>)!).count).to eql 21
+    else
+      expect(contents.scan(%r!(?=<url>)!).count).to eql 22
     end
   end
 


### PR DESCRIPTION
An ellipsis (`…`) gets incorrectly encoded to three dots (`...`).  It comes from the [`absolute_url`](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/filters/url_filters.rb#L11) filter in Jekyll, which in turn comes from [`Addressable::URI#normalize`](https://www.rubydoc.info/github/sporkmonger/addressable/Addressable/URI#normalize-instance_method).  I don't necessarily expect this will be merged, but it's the level I'm comfortable with for our requirements, so just in case anyone else wants it…