### PR TITLE
Support LATEST_POST and SITE_TIME keywords in last_modified_at front matter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]
+gem "tzinfo-data", :platforms => [:mingw, :mswin, :x64_mingw]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ When building a site that uses the GitHub Pages gem, follow the instructions abo
 The `<lastmod>` tag in the `sitemap.xml` will reflect by priority:
 
 1.   The modified date of the file as reported by the filesystem if you have `jekyll-last-modified-at` plugin installed (not compatible with GitHub Pages auto building)
-2.   A personalised date if you add the variable `last_modified_at:` with a date in the Front Matter
+2.   A personalised date if you add the variable `last_modified_at:` with a date in the Front Matter.  
+     Specify `SITE_TIME` as a value to get the time of the most recent Jekyll run, or `LATEST_POST` to get the date of
+     the most recent post (page front matter only).
 3.   The creation date of your post (corresponding to the `post.date` variable)
 
 ## Exclusions

--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -21,7 +21,14 @@
     <url>
       <loc>{{ page.url | replace:'/index.html','/' | absolute_url | xml_escape }}</loc>
       {% if page.last_modified_at %}
-        <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
+        {% if page.last_modified_at == 'SITE_TIME' %}
+          {% assign lastmod = site.time %}
+        {% elsif page.last_modified_at == 'LATEST_POST' %}
+          {% assign lastmod = site.posts.first.date %}
+        {% else %}
+          {% assign lastmod = page.last_modified_at %}
+        {% endif %}
+        <lastmod>{{ lastmod | date_to_xmlschema }}</lastmod>
       {% endif %}
     </url>
   {% endfor %}

--- a/spec/fixtures/some-subfolder/latest_post.html
+++ b/spec/fixtures/some-subfolder/latest_post.html
@@ -1,0 +1,5 @@
+---
+last_modified_at: LATEST_POST
+---
+
+uses the LATEST_POST keyword

--- a/spec/fixtures/some-subfolder/site_time.html
+++ b/spec/fixtures/some-subfolder/site_time.html
@@ -1,0 +1,5 @@
+---
+last_modified_at: SITE_TIME
+---
+
+uses the SITE_TIME keyword

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -92,6 +92,15 @@ describe(Jekyll::JekyllSitemap) do
     expect(contents).to match %r!<loc>http://example\.org/some-subfolder/</loc>!
   end
 
+  it "interprets LATEST_POST keyword correctly on pages" do
+    expect(contents).to match %r!<loc>http://example\.org/some-subfolder/latest_post.html</loc>!
+    expect(contents).to match %r!<lastmod>2016-04-03T00:00:00(-|\+)\d+:\d+</lastmod>!
+  end
+
+  it "processes page with SITE_TIME keyword" do
+    expect(contents).to match %r!<loc>http://example\.org/some-subfolder/site_time.html</loc>!
+  end
+
   it "does include assets or any static files with .xhtml and .htm extensions" do
     expect(contents).to match %r!/some-subfolder/xhtml\.xhtml!
     expect(contents).to match %r!/some-subfolder/htm\.htm!
@@ -138,9 +147,9 @@ describe(Jekyll::JekyllSitemap) do
   it "includes the correct number of items" do
     # static_files/excluded.pdf is excluded on Jekyll 3.4.2 and above
     if Gem::Version.new(Jekyll::VERSION) >= Gem::Version.new("3.4.2")
-      expect(contents.scan(%r!(?=<url>)!).count).to eql 21
+      expect(contents.scan(%r!(?=<url>)!).count).to eql 23
     else
-      expect(contents.scan(%r!(?=<url>)!).count).to eql 22
+      expect(contents.scan(%r!(?=<url>)!).count).to eql 24
     end
   end
 


### PR DESCRIPTION
This is a little PR which adds an enhancement to the `last_modified_at` front matter value in pages. Currently, the value of `last_modified_at` in a page's front matter can only be a time stamp. With this PR, it can also be one of these values:

- `SITE_TIME` – placeholder for the time of the latest Jekyll run (actually the value of `site.time`)
- `LATEST_POST` – placeholder for the date of the most recent post

Especially the latter is very helpful for a "What's new" page, which shows a list of recent posts. This "What's new" page will update whenever there is a new post, and by specifying `last_modified_at: LATEST_POST`, our sitemap can reflect that.

I also added a line to the Gemfile adding *tzinfo-data*, in order to enable running the tests on Windows.

Let me know if anything is unclear, or I misunderstood something. Thanks for considering this!