### PR TITLE
Update plugin metadata and dev environment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,5 @@
 inherit_from: .rubocop_todo.yml
 
 require: rubocop-jekyll
-
 inherit_gem:
   rubocop-jekyll: .rubocop.yml
-
-AllCops:
-  TargetRubyVersion: 2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     env: JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
 env:
   matrix:
-  - JEKYLL_VERSION=3.8
+  - JEKYLL_VERSION="~> 3.8"
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: ruby
 cache: bundler
 rvm:
+- &latest_ruby 2.6
 - 2.4
-- 2.6
+- 2.3
 matrix:
   include:
   # GitHub Pages
   - rvm: 2.5.3
     env:
-    - JEKYLL_VERSION=3.7.4
+    - JEKYLL_VERSION="~> 3.7.4"
     - GITHUB_PAGES=1 # Only set on one build in matrix
+  - rvm: *latest_ruby
+    env: JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
 env:
   matrix:
   - JEKYLL_VERSION=3.8

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@
 source "https://rubygems.org"
 gemspec
 
-gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}" if ENV["JEKYLL_VERSION"]
+gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]

--- a/jekyll-sitemap.gemspec
+++ b/jekyll-sitemap.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_dependency "jekyll", ">= 3.7", "< 5.0"
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "jekyll-last-modified-at"
+  spec.add_development_dependency "jekyll-last-modified-at", "~> 1.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop-jekyll", "~> 0.4"

--- a/jekyll-sitemap.gemspec
+++ b/jekyll-sitemap.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "jekyll", ">= 3.7", "< 5.0"
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "jekyll-last-modified-at", "~> 1.0"
+  spec.add_development_dependency "jekyll-last-modified-at"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop-jekyll", "~> 0.4"


### PR DESCRIPTION
- Re-introduce Ruby 2.3 support for backwards compatibiility
- Allow testing with Jekyll 4.0 pre-release versions