### PR TITLE
Add XML file type to INCLUDED_EXTENSIONS

### DIFF
--- a/lib/jekyll/jekyll-sitemap.rb
+++ b/lib/jekyll/jekyll-sitemap.rb
@@ -21,6 +21,7 @@ module Jekyll
       .html
       .xhtml
       .pdf
+      .xml
     ).freeze
 
     # Matches all whitespace that follows

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -101,6 +101,10 @@ describe(Jekyll::JekyllSitemap) do
     expect(contents).to match %r!/static_files/test.pdf!
   end
 
+  it "does include assets or any static files with .xml extension" do
+    expect(contents).to match %r!/static_files/test.xml!
+  end
+
   it "does not include any static files named 404.html" do
     expect(contents).not_to match %r!/static_files/404.html!
   end

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -138,9 +138,9 @@ describe(Jekyll::JekyllSitemap) do
   it "includes the correct number of items" do
     # static_files/excluded.pdf is excluded on Jekyll 3.4.2 and above
     if Gem::Version.new(Jekyll::VERSION) >= Gem::Version.new("3.4.2")
-      expect(contents.scan(%r!(?=<url>)!).count).to eql 20
-    else
       expect(contents.scan(%r!(?=<url>)!).count).to eql 21
+    else
+      expect(contents.scan(%r!(?=<url>)!).count).to eql 22
     end
   end
 


### PR DESCRIPTION
One potential use case for this would be to add XML feeds to your
sitemap. This is handy so that crawlers such as Google can better find
your feeds.

This closes #252.