### PR TITLE
Fix broken build for jekyll-sitemap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+os: linux
+dist: xenial
 cache: bundler
 rvm:
 - &latest_ruby 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ jobs:
     before_install: *addkramdowngfm
 branches:
   only:
-    - master
-      - /^v\d+\.\d+\.\d+/
+  - master
+  - /^v\d+\.\d+\.\d+/
 before_install:
 - gem update --system
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ rvm:
 - &latest_ruby 2.7
 - 2.5
 env:
-  - JEKYLL_VERSION="< 3.5.0"
-  - JEKYLL_VERSION="~> 3.5"
+  - JEKYLL_VERSION="~> 3.7"
   - JEKYLL_VERSION="~> 4.0"
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ cache: bundler
 rvm:
 - &latest_ruby 2.7
 - 2.5
-matrix:
+env:
+  - JEKYLL_VERSION="< 3.5.0"
+  - JEKYLL_VERSION="~> 3.5"
+  - JEKYLL_VERSION="~> 4.0"
+jobs:
   include:
   # GitHub Pages
   - rvm: 2.5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,15 @@ jobs:
   include:
   # GitHub Pages
   - rvm: 2.5
-    env:
-    - JEKYLL_VERSION="= 3.9.0"
-    - GITHUB_PAGES=1
+    env: &githubpages
+      - JEKYLL_VERSION="= 3.9.0"
+      - GITHUB_PAGES=1
+    before_install: &addkramdowngfm
+      - gem update --system
+      - bundle add kramdown-parser-gfm
   - rvm: *latest_ruby
-    env:
-    - JEKYLL_VERSION="= 3.9.0"
-    - GITHUB_PAGES=1
+    env: *githubpages
+    before_install: *addkramdowngfm
 before_install:
 - gem update --system
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   include:
   # GitHub Pages
-  - rvm: 2.5.3
+  - rvm: 2.5
     env:
     - JEKYLL_VERSION="~> 3.8.5"
     - GITHUB_PAGES=1 # Only set on one build in matrix

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ jobs:
   # GitHub Pages
   - rvm: 2.5
     env:
-    - JEKYLL_VERSION="=> 3.9.0"
+    - JEKYLL_VERSION="= 3.9.0"
     - GITHUB_PAGES=1
   - rvm: *latest_ruby
     env:
-    - JEKYLL_VERSION="=> 3.9.0"
+    - JEKYLL_VERSION="= 3.9.0"
     - GITHUB_PAGES=1
 before_install:
 - gem update --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,32 @@ jobs:
   - rvm: *latest_ruby
     env: *githubpages
     before_install: *addkramdowngfm
+branches:
+  only:
+    - master
+      - /^v\d+\.\d+\.\d+/
 before_install:
 - gem update --system
 install:
 - travis_retry script/bootstrap
 script: script/cibuild
+notifications:
+  irc:
+    on_success: change
+    on_failure: change
+    channels:
+    - irc.freenode.org#jekyll
+    template:
+    - "%{repository}#%{build_number} %{message} %{build_url}"
+  email:
+    on_success: never
+    on_failure: change
+deploy:
+  provider: rubygems
+  api_key:
+    secure: O8fGRnM6OJCqC2BlVE1BqYfq5aR19ulpiHhQwRiHbtSCh8H4rYt7FLsuOwSTtRQjhWYRRSpdRt2ilfQ6PY6Jx1UkxZq5zo9QAPQ9tKxiFTm7gBpZAiAgb06eyaMBSzyQ8qe2qccaFI6CiZhsiaGMsdKsWuYpuoPmdLPd7aDyYJs=
+  gem: jekyll-sitemap
+  on:
+    tags: true
+    repo: jekyll/jekyll-sitemap
+    condition: "$GITHUB_PAGES == 1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ rvm:
 - &latest_ruby 2.7
 - 2.5
 env:
-  - JEKYLL_VERSION="~> 3.7"
+  - JEKYLL_VERSION="~> 3.7.0"
+  - JEKYLL_VERSION="~> 3.8.0"
   - JEKYLL_VERSION="~> 4.0"
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,23 +25,3 @@ before_install:
 install:
 - travis_retry script/bootstrap
 script: script/cibuild
-notifications:
-  irc:
-    on_success: change
-    on_failure: change
-    channels:
-    - irc.freenode.org#jekyll
-    template:
-    - "%{repository}#%{build_number} %{message} %{build_url}"
-  email:
-    on_success: never
-    on_failure: change
-deploy:
-  provider: rubygems
-  api_key:
-    secure: O8fGRnM6OJCqC2BlVE1BqYfq5aR19ulpiHhQwRiHbtSCh8H4rYt7FLsuOwSTtRQjhWYRRSpdRt2ilfQ6PY6Jx1UkxZq5zo9QAPQ9tKxiFTm7gBpZAiAgb06eyaMBSzyQ8qe2qccaFI6CiZhsiaGMsdKsWuYpuoPmdLPd7aDyYJs=
-  gem: jekyll-sitemap
-  on:
-    tags: true
-    repo: jekyll/jekyll-sitemap
-    condition: "$GITHUB_PAGES == 1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,12 @@ jobs:
   # GitHub Pages
   - rvm: 2.5
     env:
-    - JEKYLL_VERSION="~> 3.8.5"
-    - GITHUB_PAGES=1 # Only set on one build in matrix
+    - JEKYLL_VERSION="=> 3.9.0"
+    - GITHUB_PAGES=1
   - rvm: *latest_ruby
-    env: JEKYLL_VERSION=">= 4.0.0"
-env:
-  matrix:
-  - JEKYLL_VERSION="~> 3.8"
-branches:
-  only:
-  - master
-  - /^v\d+\.\d+\.\d+/
-git:
-  depth: 1000
+    env:
+    - JEKYLL_VERSION="=> 3.9.0"
+    - GITHUB_PAGES=1
 before_install:
 - gem update --system
 install:


### PR DESCRIPTION
A couple of months ago I noticed that the build failed for my PR #254 and I finally had the opportunity to dig into why. 

In the [v3.9 release](https://jekyllrb.com/news/2020/08/05/jekyll-3-9-0-released/) of Jekyll, the kramdown dependency was changed to v2. In v2, the parsers were built into individual gems. Unfortunately, [Jekyll 3.9.0](https://rubygems.org/gems/jekyll/versions/3.9.0/dependencies) didn't include kramdown-parser-gfm as a dependency which was causing the [build failure](https://travis-ci.org/github/jekyll/jekyll-sitemap/builds/741980206).

I took the opportunity to adjust the the travis definition to explicitly build against all of the versions that jekyll-sitemap supports (>= 3.7) and included a fix for the 3.9.0 build so that the kramdown-gfm-parser would be included. 

The changes increased the number of jobs from four to eight improving the build coverage of the gem. The successful build result of all eight jobs is located [here](https://travis-ci.com/github/kriation/jekyll-sitemap/builds/210449272).