### PR TITLE
README.md how to base URL for pre-built deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ defaults:
 1. `script/bootstrap`
 2. `script/cibuild`
 
+## Base URL for pre-built deployment
+For some Jekyll users, since plugins cannot be run on GitHub pages, they opt to build locally and push their pre-built
+`_site` from the _source branch_ instead of `_root` on the _master branch_.
+In this case, to build the sitemap using the base url defined in `_config.yml` instead of "local host",
+you will first need to `build` rather than `serve` before pushing `_site` to Github, or do both consecutively; `bundle exec jekyll build & bundle exec jekyll serve`
+
 ## Known Issues
 
 1. If the `sitemap.xml` doesn't generate in the `_site` folder, ensure `_config.yml` doesn't have `safe: true`. That prevents all plugins from working.


### PR DESCRIPTION
Since GitHub Pages blocks plugins (like Jekyll-scholar), many Jekyll users pre-build their site before deploying to GitHub Pages. This is most commonly done using `bundle exec jekyll serve` on the _source branch_. However, this will fail to use the correct URL defined in the _config.yml and instead use "http://localhost".

A two sentence description is added to `README.md` to show the required usage, which will prevent people from creating an invalid sitemap, or giving up if they notice their incorrect URL despite correct `_config.yml` settings. Similar to issue #190 https://github.com/jekyll/jekyll-sitemap/issues/190 but not included in that discussion. 

Thanks for making this pugin.