### PR TITLE
Fix assets sitemap exclusion example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ sitemap: false
 
 To exclude files from your sitemap. It can be achieved with configuration using [Jekyll v3.7.2 and jekyll-sitemap v1.2.0](https://github.com/jekyll/jekyll/commit/776433109b96cb644938ffbf9caf4923bdde4d7f).
 
-Add a glob config to your `_config.yml` file. 
+Add a defaults config to your `_config.yml` file. 
 
 ```yml
 defaults:
   -
     scope:
-      path:            "assets/**/*.pdf"
+      path:            "assets"
     values:
       sitemap:         false
 ```


### PR DESCRIPTION
Double-star globbing is not allowed:
https://jekyllrb.com/docs/configuration/front-matter-defaults/#glob-patterns-in-front-matter-defaults.