### PR TITLE
Strip index name without file extension

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -8,7 +8,7 @@
     {% assign docs = collection.docs | where_exp:'doc','doc.sitemap != false' %}
     {% for doc in docs %}
       <url>
-        <loc>{{ doc.url | replace:'/index.html','/' | absolute_url | xml_escape }}</loc>
+        <loc>{{ doc.url | replace:'/index.html','/' | replace:'/index','/' | absolute_url | xml_escape }}</loc>
         {% if doc.last_modified_at or doc.date %}
           <lastmod>{{ doc.last_modified_at | default: doc.date | date_to_xmlschema }}</lastmod>
         {% endif %}


### PR DESCRIPTION
If you put an index.html file in a directory, `doc.url` will end in "/index". That's rarely what people want, as recognized by the plugin already stripping it if it includes the file extension; and the URL works with or without the "index". Even if you set a permalink with `:path`, the claimed URL will still include the generic filename, so AFAIK this can't be solved without a change to the plugin.

This could be combined with #254 if people want a page actually called "index".